### PR TITLE
Remove failure from stratum

### DIFF
--- a/open/protocols/stratum/Cargo.toml
+++ b/open/protocols/stratum/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/keytool.rs"
 bench = false
 
 [dependencies]
-failure = "0.1.5"
 thiserror = "1.0"
 lazy_static = "1.4.0"
 serde = { version = "1.0.89", features = ["derive"] }

--- a/open/protocols/stratum/Cargo.toml
+++ b/open/protocols/stratum/Cargo.toml
@@ -41,8 +41,3 @@ byte_string = "1.0.0"
 
 [features]
 v2json = []
-
-# failure caused a problem when they used private API from quote:
-# https://users.rust-lang.org/t/failure-derive-compilation-error/39062
-[patch.crates-io.failure]
-path = "../../utils-rs/failure"

--- a/open/protocols/stratum/src/error.rs
+++ b/open/protocols/stratum/src/error.rs
@@ -137,3 +137,22 @@ impl From<super::v2::serialization::Error> for Error {
 
 /// A specialized `Result` type bound to [`Error`].
 pub type Result<T> = std::result::Result<T, Error>;
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use super::super::v2::error::Error as V2Error;
+
+    #[test]
+    fn test_error_display_with_inner_error() {
+
+        let inner_msg = "Usak is unknown";
+        let inner = V2Error::UnknownMessage(inner_msg.into());
+        let err = Error::V2(inner);
+        let msg = err.to_string();
+        assert!(msg.contains(inner_msg));
+
+    }
+
+}

--- a/open/protocols/stratum/src/error.rs
+++ b/open/protocols/stratum/src/error.rs
@@ -22,7 +22,7 @@
 
 //! Module that represents stratum protocol errors
 
-use ii_async_compat::tokio_util;
+use ii_async_compat::{tokio_util, tokio};
 use std::{self, fmt, io};
 use thiserror::Error;
 
@@ -85,7 +85,7 @@ pub enum Error {
 
     /// Timeout error
     #[error("Timeout error: {0}")]
-    Timeout(#[from] ii_async_compat::Elapsed),
+    Timeout(#[from] tokio::time::Elapsed),
 
     /// Format error
     #[error("Format error: {0}")]

--- a/open/protocols/stratum/src/payload.rs
+++ b/open/protocols/stratum/src/payload.rs
@@ -27,7 +27,7 @@ use std::fmt;
 
 use ii_async_compat::bytes;
 
-use crate::error::{Result, ResultExt};
+use crate::error::Result;
 use crate::Protocol;
 
 pub use crate::AnyPayload as SerializablePayload;
@@ -116,12 +116,10 @@ impl<P: Protocol> Payload<P> {
         match &self {
             Self::SerializedBytes(payload) => writer
                 .write(payload)
-                .context("Serialize static payload")
                 .map(|_| ())
                 .map_err(Into::into),
             Self::LazyBytes(payload) => payload
                 .serialize_to_writer(writer)
-                .context("Serialize dynamic payload")
                 .map_err(Into::into),
         }
     }

--- a/open/protocols/stratum/src/v1.rs
+++ b/open/protocols/stratum/src/v1.rs
@@ -25,11 +25,11 @@ pub mod framing;
 pub mod messages;
 pub mod rpc;
 
-use self::error::ErrorKind;
+use self::error::Error;
 pub use self::framing::codec::Codec;
 pub use self::framing::{Frame, Framing};
 use self::rpc::*;
-use crate::error::{Result, ResultExt};
+use crate::error::Result;
 use crate::{AnyPayload, Message};
 
 use async_trait::async_trait;
@@ -127,7 +127,7 @@ pub fn build_message_from_frame(frame: framing::Frame) -> Result<Message<Protoco
                 Method::SetVersionMask => Box::new(messages::SetVersionMask::try_from(request)?)
                     as Box<dyn AnyPayload<Protocol>>,
                 _ => {
-                    return Err(ErrorKind::Rpc(format!("Unsupported request {:?}", request)).into())
+                    return Err(Error::Rpc(format!("Unsupported request {:?}", request)).into())
                 }
             };
             (id, payload)
@@ -141,7 +141,7 @@ pub fn build_message_from_frame(frame: framing::Frame) -> Result<Message<Protoco
             } else if response.payload.result.is_some() {
                 Box::new(response.payload.result.unwrap().clone()) as Box<dyn AnyPayload<Protocol>>
             } else {
-                return Err(ErrorKind::Rpc(format!(
+                return Err(Error::Rpc(format!(
                     "Malformed response no error, no result specified {:?}",
                     response
                 ))
@@ -197,7 +197,7 @@ impl TryFrom<&str> for HexBytes {
 
     fn try_from(value: &str) -> Result<Self> {
         Ok(HexBytes(
-            hex_decode(value).context("Parsing hex bytes failed")?,
+            hex_decode(value)?,
         ))
     }
 }
@@ -246,9 +246,9 @@ impl TryFrom<&str> for PrevHash {
         let mut prev_hash_cursor = std::io::Cursor::new(Vec::new());
 
         // Decode the plain byte array and sanity check
-        let prev_hash_stratum_order = hex_decode(value).context("Parsing hex bytes failed")?;
+        let prev_hash_stratum_order = hex_decode(value)?;
         if prev_hash_stratum_order.len() != 32 {
-            return Err(ErrorKind::Json(format!(
+            return Err(Error::Json(format!(
                 "Incorrect prev hash length: {}",
                 prev_hash_stratum_order.len()
             ))
@@ -301,7 +301,7 @@ impl TryFrom<&str> for HexU32Le {
     type Error = crate::error::Error;
 
     fn try_from(value: &str) -> Result<Self> {
-        let parsed_bytes: [u8; 4] = FromHex::from_hex(value).context("parse u32 hex value")?;
+        let parsed_bytes: [u8; 4] = FromHex::from_hex(value)?;
         Ok(HexU32Le(u32::from_le_bytes(parsed_bytes)))
     }
 }
@@ -332,7 +332,7 @@ impl TryFrom<&str> for HexU32Be {
     type Error = crate::error::Error;
 
     fn try_from(value: &str) -> Result<Self> {
-        let parsed_bytes: [u8; 4] = FromHex::from_hex(value).context("parse u32 hex value")?;
+        let parsed_bytes: [u8; 4] = FromHex::from_hex(value)?;
         Ok(HexU32Be(u32::from_be_bytes(parsed_bytes)))
     }
 }

--- a/open/protocols/stratum/src/v1/error.rs
+++ b/open/protocols/stratum/src/v1/error.rs
@@ -22,7 +22,9 @@
 
 //! Version 1 errors only
 
-#[derive(Clone, Eq, PartialEq, Debug, thiserror::Error)]
+use thiserror::Error;
+
+#[derive(Error, Clone, Eq, PartialEq, Debug)]
 pub enum Error {
     /// Json error.
     #[error("JSON error: {0}")]

--- a/open/protocols/stratum/src/v1/error.rs
+++ b/open/protocols/stratum/src/v1/error.rs
@@ -22,20 +22,18 @@
 
 //! Version 1 errors only
 
-use failure::Fail;
-
-#[derive(Clone, Eq, PartialEq, Debug, Fail)]
-pub enum ErrorKind {
+#[derive(Clone, Eq, PartialEq, Debug, thiserror::Error)]
+pub enum Error {
     /// Json error.
-    #[fail(display = "JSON error: {}", _0)]
+    #[error("JSON error: {0}")]
     Json(String),
 
-    #[fail(display = "Rpc error: {}", _0)]
+    #[error("Rpc error: {0}")]
     Rpc(String),
 
-    #[fail(display = "Subscription error: {}", _0)]
+    #[error("Subscription error: {0}")]
     Subscribe(String),
 
-    #[fail(display = "Submit error: {}", _0)]
+    #[error("Submit error: {0}")]
     Submit(String),
 }

--- a/open/protocols/stratum/src/v1/framing.rs
+++ b/open/protocols/stratum/src/v1/framing.rs
@@ -83,7 +83,6 @@ impl Frame {
 mod test {
     use super::super::{Handler, MessageId};
     use super::*;
-    use crate::error::ResultExt;
     use async_trait::async_trait;
 
     #[test]
@@ -98,7 +97,7 @@ mod test {
             }
 
             fn serialize_to_writer(&self, writer: &mut dyn std::io::Write) -> Result<()> {
-                writer.write(&EXPECTED_FRAME_BYTES).context("TestPayload")?;
+                writer.write(&EXPECTED_FRAME_BYTES)?;
                 Ok(())
             }
         }

--- a/open/protocols/stratum/src/v1/messages.rs
+++ b/open/protocols/stratum/src/v1/messages.rs
@@ -26,9 +26,9 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 
-use super::error::ErrorKind;
+use super::error::Error;
 
-use crate::error::{Result, ResultExt};
+use crate::error::Result;
 use crate::v1::{
     rpc::{self, Method},
     ExtraNonce1, HexBytes, HexU32Be, PrevHash, Protocol,
@@ -46,7 +46,7 @@ macro_rules! impl_conversion_request {
             type Error = crate::error::Error;
 
             fn try_from(msg: $request) -> Result<Self> {
-                let params = serde_json::to_value(msg).context("Cannot parse request")?;
+                let params = serde_json::to_value(msg)?;
 
                 Ok(Self {
                     method: $method,
@@ -94,7 +94,7 @@ macro_rules! impl_conversion_response {
 
             fn try_from(resp: $response) -> Result<rpc::ResponsePayload> {
                 let result = rpc::StratumResult(
-                    serde_json::to_value(resp).context("Cannot parse response")?,
+                    serde_json::to_value(resp)?,
                 );
 
                 Ok(rpc::ResponsePayload {
@@ -111,7 +111,7 @@ macro_rules! impl_conversion_response {
                 let result = resp
                     .payload
                     .result
-                    .ok_or(ErrorKind::Json("No result".into()))?;
+                    .ok_or(Error::Json("No result".into()))?;
                 <$response>::try_from(&result)
             }
         }
@@ -124,7 +124,6 @@ macro_rules! impl_conversion_response {
                 // to the visitor pattern. We shouldn't clone any part of the incoming message
                 // However, since the result is being passed by reference
                 serde_json::from_value(result.0.clone())
-                    .context("Failed to parse response")
                     .map_err(Into::into)
             }
         }
@@ -164,7 +163,7 @@ impl TryInto<(String, serde_json::Value)> for VersionRolling {
     fn try_into(self) -> Result<(String, serde_json::Value)> {
         Ok((
             "version-rolling".to_string(),
-            serde_json::to_value(self).context("JSON error")?,
+            serde_json::to_value(self)?
         ))
     }
 }
@@ -265,9 +264,9 @@ impl Subscribe {
 // Subscribe::try_from()
 //  FIXME: verify signature, url, and port?
 //  let agent_signature =
-//      req.param_to_string(0, ErrorKind::Subscribe("Invalid signature".into()))?;
-//  let url = req.param_to_string(2, ErrorKind::Subscribe("Invalid pool URL".into()))?;
-//  let port = req.param_to_string(3, ErrorKind::Subscribe("Invalid TCP port".into()))?;
+//      req.param_to_string(0, Error::Subscribe("Invalid signature".into()))?;
+//  let url = req.param_to_string(2, Error::Subscribe("Invalid pool URL".into()))?;
+//  let port = req.param_to_string(3, Error::Subscribe("Invalid TCP port".into()))?;
 impl_conversion_request!(Subscribe, Method::Subscribe, visit_subscribe);
 
 /// Custom subscriptions

--- a/open/protocols/stratum/src/v1/rpc.rs
+++ b/open/protocols/stratum/src/v1/rpc.rs
@@ -35,7 +35,7 @@ use std::convert::TryFrom;
 use std::str::FromStr;
 
 use super::{framing, Handler, Protocol};
-use crate::error::{Error, Result, ResultExt};
+use crate::error::{Error, Result};
 use crate::AnyPayload;
 
 /// All recognized methods of the V1 protocol have the 'mining.' prefix in json.
@@ -93,7 +93,7 @@ pub struct StratumResult(pub serde_json::Value);
 
 impl StratumResult {
     pub fn new_from<T: Serialize>(value: T) -> Result<Self> {
-        let value = serde_json::to_value(value).context("Failed to convert to result")?;
+        let value = serde_json::to_value(value)?;
         Ok(Self(value))
     }
 }
@@ -106,7 +106,7 @@ impl StratumResult {
 //    type Error = crate::error::Error;
 //
 //    fn try_from(value: T) -> std::result::Result<Self, Self::Error> {
-//        let value = serde_json::to_value(value).context("Failed to convert to result")?;
+//        let value = serde_json::to_value(value)?;
 //        StratumResult(value)
 //    }
 //}
@@ -232,7 +232,7 @@ impl FromStr for Rpc {
     /// Any error is being converted into JSON parsing error
     #[inline]
     fn from_str(s: &str) -> Result<Self> {
-        let x = serde_json::from_str(s).context("Parsing JSON failed")?;
+        let x = serde_json::from_str(s)?;
         Ok(x)
     }
 }

--- a/open/protocols/stratum/src/v2.rs
+++ b/open/protocols/stratum/src/v2.rs
@@ -268,7 +268,7 @@ pub fn build_message_from_frame(frame: framing::Frame) -> Result<Message<Protoco
     let payload: Box<dyn AnyPayload<Protocol>> = match MessageType::from_primitive(
         frame.header.msg_type,
     )
-    .ok_or(error::ErrorKind::UnknownMessage(
+    .ok_or(error::Error::UnknownMessage(
         format!("Unexpected payload type, full header: {:x?}", frame.header).into(),
     ))? {
         MessageType::SetupConnection => Box::new(messages::SetupConnection::try_from(frame)?),
@@ -298,7 +298,7 @@ pub fn build_message_from_frame(frame: framing::Frame) -> Result<Message<Protoco
         }
         MessageType::SubmitSharesError => Box::new(messages::SubmitSharesError::try_from(frame)?),
         _ => {
-            return Err(error::ErrorKind::UnknownMessage(
+            return Err(error::Error::UnknownMessage(
                 format!("Unexpected payload type, full header: {:?}", frame.header).into(),
             )
             .into())

--- a/open/protocols/stratum/src/v2/error.rs
+++ b/open/protocols/stratum/src/v2/error.rs
@@ -22,7 +22,9 @@
 
 //! Version 2 errors only
 
-#[derive(Clone, Eq, PartialEq, Debug, thiserror::Error)]
+use thiserror::Error;
+
+#[derive(Error, Clone, Eq, PartialEq, Debug)]
 pub enum Error {
     #[error("Unknown message error: {0}")]
     UnknownMessage(String),

--- a/open/protocols/stratum/src/v2/error.rs
+++ b/open/protocols/stratum/src/v2/error.rs
@@ -22,13 +22,11 @@
 
 //! Version 2 errors only
 
-use failure::Fail;
-
-#[derive(Clone, Eq, PartialEq, Debug, Fail)]
-pub enum ErrorKind {
-    #[fail(display = "Unknown message error: {}", _0)]
+#[derive(Clone, Eq, PartialEq, Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Unknown message error: {0}")]
     UnknownMessage(String),
 
-    #[fail(display = "Channel not operational: {}", _0)]
+    #[error("Channel not operational: {0}")]
     ChannelNotOperational(String),
 }

--- a/open/protocols/stratum/src/v2/framing.rs
+++ b/open/protocols/stratum/src/v2/framing.rs
@@ -232,7 +232,6 @@ pub const PAYLOAD_CHANNEL_OFFSET: usize = 4;
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::error::ResultExt;
     use async_trait::async_trait;
 
     #[test]
@@ -341,8 +340,7 @@ mod test {
 
             fn serialize_to_writer(&self, writer: &mut dyn std::io::Write) -> Result<()> {
                 writer
-                    .write(&EXPECTED_FRAME_BYTES[6..])
-                    .context("TestPayload")?;
+                    .write(&EXPECTED_FRAME_BYTES[6..])?;
                 Ok(())
             }
         }

--- a/open/protocols/stratum/src/v2/noise.rs
+++ b/open/protocols/stratum/src/v2/noise.rs
@@ -230,7 +230,7 @@ impl handshake::Step for Responder {
             0 => handshake::StepResult::ReceiveMessage,
             1 => {
                 // <- e
-                let in_msg = in_msg.ok_or(ErrorKind::Noise("No message arrived".to_string()))?;
+                let in_msg = in_msg.ok_or(Error::Noise("No message arrived".to_string()))?;
                 self.handshake_state.read_message(&in_msg.inner, &mut buf)?;
                 // Send the signature along this message
                 // TODO: use actual signature stored inside the responder instance

--- a/open/protocols/stratum/src/v2/noise.rs
+++ b/open/protocols/stratum/src/v2/noise.rs
@@ -33,7 +33,7 @@ use tokio_util::codec::{Framed, FramedParts};
 use ii_async_compat::prelude::*;
 use ii_wire;
 
-use crate::error::{Error, ErrorKind, Result, ResultExt};
+use crate::error::{Error, Result};
 use crate::v2;
 
 pub mod codec;
@@ -136,8 +136,7 @@ impl Initiator {
             self.authority_public_key,
         );
         certificate
-            .validate()
-            .context("Validation of certificate")?;
+            .validate()?;
 
         Ok(())
     }
@@ -163,10 +162,9 @@ impl handshake::Step for Initiator {
             }
             1 => {
                 // <- e, ee, s, es
-                let in_msg = in_msg.ok_or(ErrorKind::Noise("No message arrived".to_string()))?;
+                let in_msg = in_msg.ok_or(Error::Noise("No message arrived".to_string()))?;
                 let signature_len = self.handshake_state.read_message(&in_msg.inner, &mut buf)?;
-                self.verify_remote_static_key_signature(BytesMut::from(&buf[..signature_len]))
-                    .context("Certificate signature verification")?;
+                self.verify_remote_static_key_signature(BytesMut::from(&buf[..signature_len]))?;
                 handshake::StepResult::Done
             }
             _ => {

--- a/open/protocols/stratum/src/v2/noise/auth.rs
+++ b/open/protocols/stratum/src/v2/noise/auth.rs
@@ -29,7 +29,7 @@ use std::time::{Duration, SystemTime};
 
 use ii_async_compat::bytes;
 
-use crate::error::{Error, ErrorKind, Result, ResultExt};
+use crate::error::{Error, Result};
 use crate::v2::{self, noise::StaticPublicKey};
 
 mod formats;
@@ -186,8 +186,7 @@ impl SignatureNoiseMessage {
 
     pub fn serialize_to_bytes_mut(&self) -> Result<BytesMut> {
         let mut writer = BytesMut::new().writer();
-        self.serialize_to_writer(&mut writer)
-            .context("Serialize noise message")?;
+        self.serialize_to_writer(&mut writer)?;
 
         let serialized_signature_noise_message = writer.into_inner();
 

--- a/open/protocols/stratum/src/v2/noise/auth.rs
+++ b/open/protocols/stratum/src/v2/noise/auth.rs
@@ -71,14 +71,14 @@ impl SignedPartHeader {
     pub fn verify_expiration(&self, now: SystemTime) -> Result<()> {
         let now_timestamp = Self::system_time_to_unix_time_u32(&now)?;
         if now_timestamp < self.valid_from {
-            return Err(ErrorKind::Noise(format!(
+            return Err(Error::Noise(format!(
                 "Certificate not yet valid, valid from: {:?}, now: {:?}",
                 self.valid_from, now
             ))
             .into());
         }
         if now_timestamp > self.not_valid_after {
-            return Err(ErrorKind::Noise(format!(
+            return Err(Error::Noise(format!(
                 "Certificate expired, not valid after: {:?}, now: {:?}",
                 self.valid_from, now
             ))
@@ -91,7 +91,7 @@ impl SignedPartHeader {
         t.duration_since(SystemTime::UNIX_EPOCH)
             .map(|duration| duration.as_secs() as u32)
             .map_err(|e| {
-                ErrorKind::Noise(format!(
+                Error::Noise(format!(
                     "Cannot convert system time to unix timestamp: {}",
                     e
                 ))
@@ -103,7 +103,7 @@ impl SignedPartHeader {
         SystemTime::UNIX_EPOCH
             .checked_add(Duration::from_secs(unix_timestamp.into()))
             .ok_or(
-                ErrorKind::Noise(
+                Error::Noise(
                     format!(
                         "Cannot convert unix timestamp ({}) to system time",
                         unix_timestamp

--- a/open/protocols/stratum/src/v2/noise/handshake.rs
+++ b/open/protocols/stratum/src/v2/noise/handshake.rs
@@ -28,7 +28,7 @@ use std::time;
 
 use ii_async_compat::prelude::*;
 
-use crate::error::{ErrorKind, Result, ResultExt};
+use crate::error::{Error, Result};
 
 /// Handshake message
 #[derive(Debug, Clone, PartialEq)]
@@ -98,11 +98,10 @@ where
         let handshake_frame: BytesMut = handshake_stream
             .next()
             .timeout(Self::HANDSHAKE_TIMEOUT)
-            .await
-            .context("Receive timeout")?
+            .await?
             // Convert optional frame into an error, unwrap it, and unwrap the
             // payload, too
-            .ok_or(ErrorKind::Io(
+            .ok_or(Error::Io(
                 "Noise handshake Connection shutdown".to_string(),
             ))??;
         Ok(Message::new(handshake_frame))
@@ -132,8 +131,7 @@ where
                     handshake_stream
                         .send(out_msg.inner)
                         .timeout(Self::HANDSHAKE_TIMEOUT)
-                        .await
-                        .context("Send timeout")??;
+                        .await??;
 
                     let handshake_message = self.receive_message(handshake_stream).await?;
                     (&mut in_msg).replace(handshake_message);
@@ -142,8 +140,7 @@ where
                     handshake_stream
                         .send(out_msg.inner)
                         .timeout(Self::HANDSHAKE_TIMEOUT)
-                        .await
-                        .context("Handshake send timeout")??;
+                        .await??;
                 }
                 // Initiator is now finalized
                 StepResult::Done => {

--- a/open/protocols/stratum/src/v2/noise/handshake.rs
+++ b/open/protocols/stratum/src/v2/noise/handshake.rs
@@ -101,7 +101,7 @@ where
             .await?
             // Convert optional frame into an error, unwrap it, and unwrap the
             // payload, too
-            .ok_or(Error::Io(
+            .ok_or(Error::Handshake(
                 "Noise handshake Connection shutdown".to_string(),
             ))??;
         Ok(Message::new(handshake_frame))

--- a/open/protocols/stratum/src/v2/telemetry/messages.rs
+++ b/open/protocols/stratum/src/v2/telemetry/messages.rs
@@ -148,7 +148,7 @@ pub fn build_message_from_frame(frame: framing::Frame) -> Result<Message<Protoco
     let payload: Box<dyn AnyPayload<Protocol>> = match MessageType::from_primitive(
         frame.header.msg_type,
     )
-    .ok_or(error::ErrorKind::UnknownMessage(
+    .ok_or(error::Error::UnknownMessage(
         format!("Unexpected payload type, full header: {:x?}", frame.header).into(),
     ))? {
         MessageType::OpenTelemetryChannel => Box::new(OpenTelemetryChannel::try_from(frame)?),

--- a/open/stratum-proxy/Cargo.lock
+++ b/open/stratum-proxy/Cargo.lock
@@ -699,7 +699,6 @@ dependencies = [
  "bs58",
  "byteorder",
  "ed25519-dalek",
- "failure",
  "hex",
  "ii-async-compat",
  "ii-bitcoin",

--- a/open/utils-rs/async-compat/src/lib.rs
+++ b/open/utils-rs/async-compat/src/lib.rs
@@ -41,8 +41,6 @@ pub mod prelude {
 }
 
 pub use stream_cancel::{self, Tripwire};
-/// Tokio timeout error
-pub use tokio::time::Elapsed; 
 
 use std::error::Error as StdError;
 use std::fmt;

--- a/open/utils-rs/async-compat/src/lib.rs
+++ b/open/utils-rs/async-compat/src/lib.rs
@@ -41,7 +41,8 @@ pub mod prelude {
 }
 
 pub use stream_cancel::{self, Tripwire};
-pub use tokio::time::Elapsed as TimeoutError; //TODO: Is this good practice to reexport under different name ?
+/// Tokio timeout error
+pub use tokio::time::Elapsed; 
 
 use std::error::Error as StdError;
 use std::fmt;

--- a/open/utils-rs/async-compat/src/lib.rs
+++ b/open/utils-rs/async-compat/src/lib.rs
@@ -41,6 +41,7 @@ pub mod prelude {
 }
 
 pub use stream_cancel::{self, Tripwire};
+pub use tokio::time::Elapsed as TimeoutError; //TODO: Is this good practice to reexport under different name ?
 
 use std::error::Error as StdError;
 use std::fmt;


### PR DESCRIPTION
Replacing `failure` crate with `thiserror` - first attempt.

All tests within crate stratum work, but not sure how it impacts remaining code yet.

Now it's rather for discussion, then ready to be merged.

I.