### PR TITLE
Add option to call `miner fault_light` with no args.

### DIFF
--- a/braiins-os/package/mining/miner_tools/files/miner
+++ b/braiins-os/package/mining/miner_tools/files/miner
@@ -60,6 +60,15 @@ ip_report() {
 }
 
 fault_light() {
+  if [ $# -eq 0 ]; then
+    if [ -e /sys/class/leds/"Red LED"/delay_on ]; then
+      echo "on"
+      exit 0
+    else
+      echo "off"
+      exit 0
+    fi
+  fi
 	if [ $# -ne 1 -o \( "$1" != 'on' -a "$1" != 'off' \) ]; then
 		echo "command 'fault_light' takes only one argument [on|off]" >&2
 		exit 1


### PR DESCRIPTION
Calling `miner fault_light` with no args will check for a file, `/sys/class/leds/"Red LED"/delay_on` which is removed when the fault light is turned off, but gets created when it is turned on.